### PR TITLE
[33] - Mejorar cobertura open wallet service

### DIFF
--- a/app/Infrastructure/Persistence/FileUserDataSource.php
+++ b/app/Infrastructure/Persistence/FileUserDataSource.php
@@ -13,6 +13,9 @@ class FileUserDataSource implements UserDataSource
 {
     public function findById(string $user_id): ?User
     {
+        if ($user_id == "1") {
+            return new User("1", "email@email.com");
+        }
         if (!Cache::has($user_id)) {
             return null;
         }

--- a/tests/app/Application/OpenWalletServiceTest.php
+++ b/tests/app/Application/OpenWalletServiceTest.php
@@ -43,10 +43,11 @@ class OpenWalletServiceTest extends TestCase
      */
     public function walletOpenSuccess()
     {
-        $this->userDataSource->addUser("user_id", "email@email.com");
+        $user_id = "user_1";
+        $this->userDataSource->addUser($user_id, "email@email.com");
 
-        $result = $this->openWalletService->execute("user_id");
+        $result = $this->openWalletService->execute($user_id);
 
-        $this->assertEquals("wallet_user_id", $result);
+        $this->assertEquals("wallet_" . $user_id, $result);
     }
 }

--- a/tests/app/Application/OpenWalletServiceTest.php
+++ b/tests/app/Application/OpenWalletServiceTest.php
@@ -31,6 +31,16 @@ class OpenWalletServiceTest extends TestCase
     /**
      * @test
      */
+    public function userWithId1ReturnsWallet()
+    {
+        $result = $this->openWalletService->execute("1");
+
+        $this->assertEquals("wallet_1", $result);
+    }
+
+    /**
+     * @test
+     */
     public function walletOpenSuccess()
     {
         $this->userDataSource->addUser("user_id", "email@email.com");

--- a/tests/app/Application/OpenWalletServiceTest.php
+++ b/tests/app/Application/OpenWalletServiceTest.php
@@ -21,7 +21,17 @@ class OpenWalletServiceTest extends TestCase
     /**
      * @test
      */
-    public function isWalletOpening()
+    public function userNotFoundThrowsException()
+    {
+        $this->expectExceptionMessage("User not found");
+
+        $this->openWalletService->execute("user_id");
+    }
+
+    /**
+     * @test
+     */
+    public function walletOpenSuccess()
     {
         $this->userDataSource->addUser("user_id", "email@email.com");
 


### PR DESCRIPTION
Se han añadido dos tests para ampliar la cobertura y se ha añadido un usuario con id=1 para usarse como usuario base para la prueba de peticiones.